### PR TITLE
Add support for objective-c

### DIFF
--- a/src/withRevopush.ts
+++ b/src/withRevopush.ts
@@ -61,6 +61,23 @@ const withIosPlugin: ConfigPlugin<RevopushConfig> = (config, {ios}) => {
                 );
                 break;
             }
+            case 'objc':
+            case 'objcpp': {
+                config.modResults.contents = mergeContents({
+                    src: modResults.contents,
+                    comment: '//',
+                    tag: 'revopush-updates-header',
+                    offset: 1,
+                    anchor: /#import "AppDelegate\.h"/,
+                    newSrc: '#import <CodePush/CodePush.h>',
+                }).contents;
+
+                config.modResults.contents = config.modResults.contents.replace(
+                    /return \[\[NSBundle mainBundle\] URLForResource:@"main" withExtension:@"jsbundle"\];/,
+                    'return [CodePush bundleURL];'
+                );
+                break;
+            }
             default: {
                 throw new Error(`Revopush plugin doesn't support language: ${language}`);
             }


### PR DESCRIPTION
My expo project still outputs the iOS directory using objective-c. Looking at the iOS guide for RN (non-expo) I think it should still work fine by adding CodePush to the objective-c files?

I tested by patching locally and it seemed to work fine. But not sure if there was some other reason you only had Swift support.